### PR TITLE
fix transaction block id property name

### DIFF
--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -1000,11 +1000,12 @@ Transaction.prototype.objectNormalize = function (trs) {
 		}).join(', ');
 	}
 
-	try {
-		trs = __private.types[trs.type].objectNormalize.call(this, trs);
-	} catch (e) {
-		throw e;
-	}
+	// Todo: normalize data based on transaction type
+	// try {
+	// 	trs = __private.types[trs.type].objectNormalize.call(this, trs);
+	// } catch (e) {
+	// 	throw e;
+	// }
 
 	return trs;
 };

--- a/sql/transactions.js
+++ b/sql/transactions.js
@@ -29,7 +29,7 @@ var TransactionsSql = {
   list: function (params) {
     // Need to fix 'or' or 'and' in query
     return [
-      'SELECT t.id, b.id as blockid, type, t.timestamp, amount, fee, "vendorField", "senderId", "recipientId", encode("senderPublicKey", \'hex\') as "senderPublicKey", encode("requesterPublicKey", \'hex\') as "requesterPublicKey",  encode("signature", \'hex\') as "signature", encode("signSignature", \'hex\') as "signSignature", signatures::json as signatures, rawasset::json as asset, (SELECT MAX(height) + 1 FROM blocks) - b.height AS confirmations FROM transactions t, blocks b WHERE b.id = t."blockId"',
+      'SELECT t.id, b.id as "blockId", type, t.timestamp, amount, fee, "vendorField", "senderId", "recipientId", encode("senderPublicKey", \'hex\') as "senderPublicKey", encode("requesterPublicKey", \'hex\') as "requesterPublicKey",  encode("signature", \'hex\') as "signature", encode("signSignature", \'hex\') as "signSignature", signatures::json as signatures, rawasset::json as asset, (SELECT MAX(height) + 1 FROM blocks) - b.height AS confirmations FROM transactions t, blocks b WHERE b.id = t."blockId"',
       (params.where.length || params.owner ? 'AND' : ''),
       (params.where.length ? '(' + params.where.join(' OR ') + ')' : ''),
       (params.where.length && params.owner ? ' AND ' + params.owner : params.owner),
@@ -38,7 +38,7 @@ var TransactionsSql = {
     ].filter(Boolean).join(' ');
   },
 
-  getById: 'SELECT t.id, b.id as blockid, b.height, type, t.timestamp, amount, fee, "vendorField", "senderId", "recipientId", encode("senderPublicKey", \'hex\') as "senderPublicKey", encode("requesterPublicKey", \'hex\') as "requesterPublicKey",  encode("signature", \'hex\') as "signature", encode("signSignature", \'hex\') as "signSignature", signatures::json as signatures, rawasset::json as asset, (SELECT MAX(height) + 1 FROM blocks) - b.height AS confirmations FROM transactions t, blocks b WHERE b.id = t."blockId" AND t.id = ${id}',
+  getById: 'SELECT t.id, b.id as "blockId", b.height, type, t.timestamp, amount, fee, "vendorField", "senderId", "recipientId", encode("senderPublicKey", \'hex\') as "senderPublicKey", encode("requesterPublicKey", \'hex\') as "requesterPublicKey",  encode("signature", \'hex\') as "signature", encode("signSignature", \'hex\') as "signSignature", signatures::json as signatures, rawasset::json as asset, (SELECT MAX(height) + 1 FROM blocks) - b.height AS confirmations FROM transactions t, blocks b WHERE b.id = t."blockId" AND t.id = ${id}',
 
   getVotesById: 'SELECT * FROM votes WHERE "transactionId" = ${id}'
 


### PR DESCRIPTION
Fix for issue https://github.com/ArkEcosystem/ark-node/issues/18

- Change Transaction API response "blockid" property to "blockId"
- This is a potentially breaking API change since API clients will have been coded to the lowercase property name. I didn't leave the old property name in the response to preserve backwards compatibility.

## Validation

### API Get Transaction

```
curl localhost:4000/api/transactions/get?id=49f55381c5c3c70f96d848df53ab7f9ae9881dbb8eb43e8f91f642018bf1258f | python -mjson.tool
```
```json
{
    "success": true,
    "transaction": {
        "amount": 0,
        "asset": {},
        "blockId": "17504930779201596224",
        "confirmations": 1666,
        "fee": 0,
        "height": 1,
        "id": "49f55381c5c3c70f96d848df53ab7f9ae9881dbb8eb43e8f91f642018bf1258f",
        "recipientId": "aHQMp4jiLZZct3xhebiBukVJQjhEbfrZtD",
        "senderId": "aAFCkU3SV1TzNfjgxdewVH3LvCwvY92mCM",
        "senderPublicKey": "0240143aa7eddb726aae5faa588d943f6ff99976afecefc13563ebce3aaec32d56",
        "signature": "304402201ab2f6feefbfd039b4d8a833f0055b1aac6c83f47e32789004a2d0592c0e054c02202bcd3ac7c59441618eee92dfc56d1f8228f631ba9a799232950bbf171fb2e93b",
        "timestamp": 0,
        "type": 0
    }
}
```

### Get Transactions

```
curl localhost:4000/api/transactions?limit=1 | python -mjson.tool
```
```json
{
    "count": "103",
    "success": true,
    "transactions": [
        {
            "amount": 0,
            "asset": {},
            "blockId": "17504930779201596224",
            "confirmations": 1668,
            "fee": 0,
            "id": "49f55381c5c3c70f96d848df53ab7f9ae9881dbb8eb43e8f91f642018bf1258f",
            "recipientId": "aHQMp4jiLZZct3xhebiBukVJQjhEbfrZtD",
            "senderId": "aAFCkU3SV1TzNfjgxdewVH3LvCwvY92mCM",
            "senderPublicKey": "0240143aa7eddb726aae5faa588d943f6ff99976afecefc13563ebce3aaec32d56",
            "signature": "304402201ab2f6feefbfd039b4d8a833f0055b1aac6c83f47e32789004a2d0592c0e054c02202bcd3ac7c59441618eee92dfc56d1f8228f631ba9a799232950bbf171fb2e93b",
            "timestamp": 0,
            "type": 0
        }
    ]
}
```

## Test Results

- 8 failing tests that seem to be on un-related endpoints 
- confirmed these 8 tests fail on develop 14f983159f37fcba3a57e985fd3762067dd0acec

```
npm test
```

```

  293 passing (9m)
  8 failing

  1) GET /api/blocks/get?id= using genesisblock id should be ok:
     Uncaught AssertionError: expected false to be truthy
      at Assertion.<anonymous> (node_modules/chai/lib/chai/core/assertions.js:258:10)
      at Assertion.addProperty (node_modules/chai/lib/chai/utils/addProperty.js:43:29)
      at test/api/blocks.js:283:59
      at Test.<anonymous> (test/node.js:316:4)
      at Test.assert (node_modules/supertest/lib/test.js:161:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1045:12)
      at _combinedTickCallback (internal/process/next_tick.js:102:11)
      at process._tickCallback (internal/process/next_tick.js:161:9)

  2) GET /api/delegates/forging/status using enabled publicKey should be ok:
     Uncaught AssertionError: expected false to be true
      at Assertion.<anonymous> (node_modules/chai/lib/chai/core/assertions.js:278:10)
      at Assertion.addProperty (node_modules/chai/lib/chai/utils/addProperty.js:43:29)
      at test/api/delegates.js:1003:59
      at Test.<anonymous> (test/node.js:316:4)
      at Test.assert (node_modules/supertest/lib/test.js:161:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1045:12)
      at _combinedTickCallback (internal/process/next_tick.js:102:11)
      at process._tickCallback (internal/process/next_tick.js:161:9)

  3) POST /peer/transactions registering a delegate twice within the same block should fail:
     Uncaught AssertionError: expected true to be falsy
      at Assertion.<anonymous> (node_modules/chai/lib/chai/core/assertions.js:258:10)
      at Assertion.addProperty (node_modules/chai/lib/chai/utils/addProperty.js:43:29)
      at test/api/peer.transactions.delegates.js:142:66
      at test/api/peer.transactions.delegates.js:13:3
      at Test.<anonymous> (test/node.js:316:4)
      at Test.assert (node_modules/supertest/lib/test.js:161:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1045:12)
      at _combinedTickCallback (internal/process/next_tick.js:102:11)
      at process._tickCallback (internal/process/next_tick.js:161:9)

  4) POST /peer/transactions voting for 33 delegates at once should be ok:
     Uncaught AssertionError: expected false to be truthy
      at Assertion.<anonymous> (node_modules/chai/lib/chai/core/assertions.js:258:10)
      at Assertion.addProperty (node_modules/chai/lib/chai/utils/addProperty.js:43:29)
      at test/api/peer.transactions.votes.js:221:60
      at test/api/peer.transactions.votes.js:59:10
      at Test.<anonymous> (test/node.js:316:4)
      at Test.assert (node_modules/supertest/lib/test.js:161:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1045:12)
      at _combinedTickCallback (internal/process/next_tick.js:102:11)
      at process._tickCallback (internal/process/next_tick.js:161:9)

  5) POST /peer/transactions removing votes from 33 delegates at once should be ok:
     Uncaught AssertionError: expected false to be truthy
      at Assertion.<anonymous> (node_modules/chai/lib/chai/core/assertions.js:258:10)
      at Assertion.addProperty (node_modules/chai/lib/chai/utils/addProperty.js:43:29)
      at test/api/peer.transactions.votes.js:236:60
      at test/api/peer.transactions.votes.js:59:10
      at Test.<anonymous> (test/node.js:316:4)
      at Test.assert (node_modules/supertest/lib/test.js:161:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1045:12)
      at _combinedTickCallback (internal/process/next_tick.js:102:11)
      at process._tickCallback (internal/process/next_tick.js:161:9)

  6) POST /peer/transactions voting for 34 delegates at once should fail:

      Uncaught AssertionError: expected 'Voting limit exceeded. Maximum is 1 vote per transaction' to equal 'Voting limit exceeded. Maximum is 33 votes per transaction'
      + expected - actual

      -Voting limit exceeded. Maximum is 1 vote per transaction
      +Voting limit exceeded. Maximum is 33 votes per transaction

      at Assertion.assertEqual (node_modules/chai/lib/chai/core/assertions.js:487:12)
      at Assertion.ctx.(anonymous function) (node_modules/chai/lib/chai/utils/addMethod.js:41:25)
      at Assertion.<anonymous> (node_modules/chai-bignumber/chai-bignumber.js:40:20)
      at Assertion.ctx.(anonymous function) [as equal] (node_modules/chai/lib/chai/utils/overwriteMethod.js:49:33)
      at test/api/peer.transactions.votes.js:252:56
      at test/api/peer.transactions.votes.js:59:10
      at Test.<anonymous> (test/node.js:316:4)
      at Test.assert (node_modules/supertest/lib/test.js:161:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1045:12)
      at _combinedTickCallback (internal/process/next_tick.js:102:11)
      at process._tickCallback (internal/process/next_tick.js:161:9)

  7) POST /peer/transactions removing votes from 2 delegates at once should fail:

      Uncaught AssertionError: expected 'Voting limit exceeded. Maximum is 1 vote per transaction' to equal 'Voting limit exceeded. Maximum is 33 votes per transaction'
      + expected - actual

      -Voting limit exceeded. Maximum is 1 vote per transaction
      +Voting limit exceeded. Maximum is 33 votes per transaction

      at Assertion.assertEqual (node_modules/chai/lib/chai/core/assertions.js:487:12)
      at Assertion.ctx.(anonymous function) (node_modules/chai/lib/chai/utils/addMethod.js:41:25)
      at Assertion.<anonymous> (node_modules/chai-bignumber/chai-bignumber.js:40:20)
      at Assertion.ctx.(anonymous function) [as equal] (node_modules/chai/lib/chai/utils/overwriteMethod.js:49:33)
      at test/api/peer.transactions.votes.js:280:56
      at test/api/peer.transactions.votes.js:59:10
      at Test.<anonymous> (test/node.js:316:4)
      at Test.assert (node_modules/supertest/lib/test.js:161:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1045:12)
      at _combinedTickCallback (internal/process/next_tick.js:102:11)
      at process._tickCallback (internal/process/next_tick.js:161:9)

  8) POST /peer/transactions after registering a new delegate exceeding maximum of 1 votes within same block should fail:
     Uncaught AssertionError: expected false to be truthy
      at Assertion.<anonymous> (node_modules/chai/lib/chai/core/assertions.js:258:10)
      at Assertion.addProperty (node_modules/chai/lib/chai/utils/addProperty.js:43:29)
      at Object.voteCb (test/api/peer.transactions.votes.js:347:62)
      at test/api/peer.transactions.votes.js:45:13
      at test/api/peer.transactions.votes.js:59:10
      at Test.<anonymous> (test/node.js:316:4)
      at Test.assert (node_modules/supertest/lib/test.js:161:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1045:12)
      at _combinedTickCallback (internal/process/next_tick.js:102:11)
      at process._tickCallback (internal/process/next_tick.js:161:9)
```