### PR TITLE
Added Ability to query delegate by specifying its address with no impact on node stability/load.

### DIFF
--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -760,8 +760,10 @@ shared.getDelegate = function (req, cb) {
 				if (req.body.publicKey) {
 					return delegate.publicKey === req.body.publicKey;
 				} else if (req.body.username) {
-					return delegate.username === req.body.username;
-				}
+          return delegate.username === req.body.username;
+        } else if (req.body.address) {
+          return delegate.address === req.body.address;
+        }
 
 				return false;
 			});

--- a/schema/delegates.js
+++ b/schema/delegates.js
@@ -55,7 +55,12 @@ module.exports = {
 			},
 			username: {
 				type: 'string'
-			}
+			},
+      address: {
+        type: 'string',
+        minLength: 1,
+        format: 'address'
+      }
 		}
 	},
 	search: {


### PR DESCRIPTION
Hey,

I noticed that we cannot query delegates by their address.
Since the filtering is done through a filter predicate in nodejs I figured that it might be helpful to others (as I noticed it cause I needed it :P)

Hope it helps.