### PR TITLE
Cast BIGINT to JS Int from Postgres

### DIFF
--- a/helpers/database.js
+++ b/helpers/database.js
@@ -120,6 +120,10 @@ module.exports.connect = function (config, logger, cb) {
 	var pgp = require('pg-promise')(pgOptions);
 	var monitor = require('pg-monitor');
 
+        pgp.pg.types.setTypeParser(20, function (value) {
+            return parseInt(value);
+        });
+
 	monitor.attach(pgOptions, config.logEvents);
 	monitor.setTheme('matrix');
 


### PR DESCRIPTION
Resolves #30 

This could cause issues, so subject to review. 64bit integer is not supposed in JS, hence why it is returned as a string.

It is documented here:
https://stackoverflow.com/a/9643650
https://github.com/brianc/node-pg-types#use