### PR TITLE
Ark Infra - Add bin and pkg properties to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ark-node",
   "version": "0.2.0",
   "private": true,
+  "bin": "app.js",
   "scripts": {
     "start": "node app.js",
     "doc": "docco -t docs/template/arkio.jst -c docs/template/arkio.css modules/* app.js README.md",
@@ -85,5 +86,9 @@
         "tmp"
       ]
     }
+  },
+  "pkg": {
+    "scripts": "modules/**",
+    "assets": "sql/**"
   }
 }


### PR DESCRIPTION
I'm doing -> https://github.com/yograterol/ark-infra/ and I need to have `bin` and `pkg` properties on the package.json

It's a project to create Ark's Docker images and compile Ark in a single binary with all modules.

Here the result in console:

![image](https://user-images.githubusercontent.com/3322886/30246359-3c95ecf0-95bd-11e7-9118-b52bc0717eb8.png)

Dockerfile: https://github.com/yograterol/ark-infra/blob/master/Dockerfile-mainnet
