### PR TITLE
Create output dir if not exists

### DIFF
--- a/tasks/createGenesisBlock.js
+++ b/tasks/createGenesisBlock.js
@@ -366,6 +366,11 @@ var genesisBlock = create({
 
 config.nethash = genesisBlock.payloadHash;
 
+// create directory
+if (!fs.existsSync(output_dir)) {
+    fs.mkdirSync(output_dir);
+}
+
 fs.writeFile(output_dir+"/genesisBlock."+config.network+".json",JSON.stringify(genesisBlock, null, 2));
 fs.writeFile(output_dir+"/config."+config.network+".json",JSON.stringify(config, null, 2));
 


### PR DESCRIPTION
If dir is't exist the following error returns: 

**Error: ENOENT: no such file or directory, open './demo/genesisBlock.vixcoin.json'**

Edit: Resolves #61 