### PR TITLE
Update ‘moment’ dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "jsdox": "=0.4.10",
     "jshint": "=2.9.3",
     "mocha": "=3.1.0",
-    "moment": "=2.15.1",
+    "moment": "=2.19.3",
     "supertest": "=2.0.0"
   },
   "config": {


### PR DESCRIPTION
 per GitHib vulnerability alert.
Update ```”moment”: “=2.15.1”``` to ```”moment”: “=2.19.3”```

Reference:
https://nvd.nist.gov/vuln/detail/CVE-2017-18214