### PR TITLE
minor changes to developer install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,14 @@ sudo apt-get install -y curl build-essential python git
 Install PostgreSQL (min version: 9.5.2)
 
 ```
-sudo apt-get install -y postgresql postgresql-contrib
+sudo apt-get install -y postgresql postgresql-contrib libpq-dev
 sudo -u postgres createuser --createdb --password $USER
-createdb ark_test
 ```
 
 Install Node.js (tested with version 6.9.2, but any recent LTS release should do):
 
 ```
-sudo apt-get install -y nodejs
+sudo apt-get install -y nodejs npm
 sudo npm install -g n
 sudo n 6.9.2
 ```


### PR DESCRIPTION
made the following changes
- added libpq-dev install to postgresql to prevent "you need to install postgresql-server-dev-X.Y" error during node modules install
- removed db creation from postgres install as it's redundent with start instructions below
- added npm install with nodejs