### PR TITLE
adds toLowerCase() to comparison in getDelegate function

### DIFF
--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -760,7 +760,7 @@ shared.getDelegate = function (req, cb) {
 				if (req.body.publicKey) {
 					return delegate.publicKey === req.body.publicKey;
 				} else if (req.body.username) {
-					return delegate.username === req.body.username;
+					return delegate.username.toLowerCase() === req.body.username.toLowerCase();
 				}
 
 				return false;


### PR DESCRIPTION
while not a problem per se, the case sensitivity is most notably on the explorer when searching for a delegate, e.g. `Jarunik` returns no matches, while `jarunik` redirects to the delegates wallet.

![image](https://user-images.githubusercontent.com/6547002/40664841-1d6d4f90-635c-11e8-903b-5f4f27322870.png)
