### PR TITLE
Fix Mainnet Peer Propogation

### DIFF
--- a/config.mainnet.json
+++ b/config.mainnet.json
@@ -34,6 +34,7 @@
     }
   },
   "peers": {
+    "queryReach": 20,
     "minimumNetworkReach": 20,
     "list": [
       {"ip":"5.39.9.240", "port":4001},

--- a/config.mainnet.json
+++ b/config.mainnet.json
@@ -1,7 +1,7 @@
 {
   "port": 4001,
   "address": "0.0.0.0",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "fileLogLevel": "info",
   "logFileName": "logs/ark.log",
   "consoleLogLevel": "info",

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -111,12 +111,12 @@ __private.updatePeersList = function (cb) {
 				.slice(0, reach); // don't query everyone - that would be spammy
 
 			async.each(peers, function (peer, eachCb) {
-
 				peer = self.inspect(peer);
 
 				library.schema.validate(peer, schema.updatePeersList.peer, function (err) {
 					if (err) {
 						err.forEach(function (e) {
+							library.logger.error(['Rejecting invalid peer:', peer.ip, e.path, e.message].join(' '));
 						});
 
 					} else {

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -108,8 +108,8 @@ __private.updatePeersList = function (cb) {
 
 			var peers = res.body.peers
 				.filter(peer => peer.ip.substr(0,3) != "127") // exclude loopback addresses
+				.peers.sort((a, b) => return 0.5 - Math.random()) // randomize the list to prevent malicious list crafting
 				.slice(0, reach); // don't query everyone - that would be spammy
-				.peers.sort((a, b) => a.delay - b.delay) // sort by delay
 
 			async.each(peers, function (peer, eachCb) {
 				peer = self.inspect(peer);

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -107,8 +107,9 @@ __private.updatePeersList = function (cb) {
 			var reach = library.config.peers.queryReach || 20;
 
 			var peers = res.body.peers
-				.filter(peer => peer.ip.substr(0,3) != 127) // exclude loopback addresses
+				.filter(peer => peer.ip.substr(0,3) != "127") // exclude loopback addresses
 				.slice(0, reach); // don't query everyone - that would be spammy
+				.peers.sort((a, b) => a.delay - b.delay) // sort by delay
 
 			async.each(peers, function (peer, eachCb) {
 				peer = self.inspect(peer);

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -108,7 +108,7 @@ __private.updatePeersList = function (cb) {
 
 			var peers = res.body.peers
 				.filter(peer => peer.ip.substr(0,3) != "127") // exclude loopback addresses
-				.sort((a, b) => 0.5 - Math.random()) // randomize the list to prevent malicious list crafting
+				.sort(() => 0.5 - Math.random()) // randomize the list to prevent malicious list crafting
 				.slice(0, reach); // don't query everyone - that would be spammy
 
 			async.each(peers, function (peer, eachCb) {

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -108,7 +108,7 @@ __private.updatePeersList = function (cb) {
 
 			var peers = res.body.peers
 				.filter(peer => peer.ip.substr(0,3) != "127") // exclude loopback addresses
-				.peers.sort((a, b) => 0.5 - Math.random()) // randomize the list to prevent malicious list crafting
+				.sort((a, b) => 0.5 - Math.random()) // randomize the list to prevent malicious list crafting
 				.slice(0, reach); // don't query everyone - that would be spammy
 
 			async.each(peers, function (peer, eachCb) {

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -106,10 +106,11 @@ __private.updatePeersList = function (cb) {
 
 			var reach = library.config.peers.queryReach || 20;
 
-			var peers = res.body.peers
-				.filter(peer => peer.ip.substr(0,3) != "127") // exclude loopback addresses
-				.sort(() => 0.5 - Math.random()) // randomize the list to prevent malicious list crafting
-				.slice(0, reach); // don't query everyone - that would be spammy
+			var peers = shuffle(
+							res.body.peers
+								.filter(peer => peer.ip.substr(0,3) != "127") // exclude loopback addresses
+						) // randomize the list to prevent malicious list crafting
+						.slice(0, reach); // don't query everyone - that would be spammy
 
 			async.each(peers, function (peer, eachCb) {
 				peer = self.inspect(peer);

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -108,7 +108,7 @@ __private.updatePeersList = function (cb) {
 
 			var peers = res.body.peers
 				.filter(peer => peer.ip.substr(0,3) != "127") // exclude loopback addresses
-				.peers.sort((a, b) => return 0.5 - Math.random()) // randomize the list to prevent malicious list crafting
+				.peers.sort((a, b) => 0.5 - Math.random()) // randomize the list to prevent malicious list crafting
 				.slice(0, reach); // don't query everyone - that would be spammy
 
 			async.each(peers, function (peer, eachCb) {


### PR DESCRIPTION
This will fix the current peer situation on mainnet as well as stop a different issue from occurring when a peer returns a completely falsified peer list that is never verified.