### PR TITLE
add unique indexes to votes / delegates

### DIFF
--- a/sql/migrations/20180814120000_add_unique_constraint_to_votes.sql
+++ b/sql/migrations/20180814120000_add_unique_constraint_to_votes.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS "votes_uniq" ON votes ("votes", "transactionId");
+
+COMMIT;

--- a/sql/migrations/20180814130000_add_unique_constraint_to_delegates.sql
+++ b/sql/migrations/20180814130000_add_unique_constraint_to_delegates.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS "delegates_username_uniq" ON delegates ("username");
+CREATE INDEX IF NOT EXISTS "delegates_transactionId_uniq" ON delegates ("transactionId");
+
+COMMIT;


### PR DESCRIPTION
`votes` and `delegates` do not contain unique indexes, meaning a bad restore can contain duplicate entries, affecting the forging order.

The votes_uniq does allow multiple votes per transaction (although application logic would prevent this in Ark) in order for v1 bridgechains that have allowed more than one vote per transaction to continue functioning, while still providing protection against duplications.

To enforce a single vote per transaction, but at risk of breaking other chains, then the index should be changed to:

`CREATE INDEX IF NOT EXISTS "votes_uniq" ON votes ("transactionId");`