### PR TITLE
Use an object instead of an array to avoid duplicates. Untested. Don't merge yet.

### DIFF
--- a/modules/transactionPool.js
+++ b/modules/transactionPool.js
@@ -360,7 +360,6 @@ TransactionPool.prototype.receiveTransactions = function (transactions, cb) {
 			__private.processVerifyTransaction(transaction, function (err) {
 				if (!err) {
 					__private.mempool[transaction.id]=transaction;
-					library.logger.info("tx added to mempool", transaction.id);
 					return self.queueTransaction(transaction, eachSeriesCb);
 				} else {
 					// delete all invalid txs after 1 min

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -18,7 +18,7 @@ var modules, library, self, __private = {}, shared = {};
 
 __private.headers = {};
 __private.messages = {};
-__private.broadcastTransactions = [];
+__private.broadcastTransactions = {};
 
 // Constructor
 function Transport (cb, scope) {
@@ -27,9 +27,13 @@ function Transport (cb, scope) {
 
 	setInterval(function(){
 		var maxspliced = 10;
-		if(maxspliced > __private.broadcastTransactions.length) maxspliced = __private.broadcastTransactions.length;
+		if(maxspliced > Object.keys(__private.broadcastTransactions).length) maxspliced = Object.keys(__private.broadcastTransactions).length;
 		if(maxspliced > 0){
-			var transactions = __private.broadcastTransactions.splice(0, maxspliced);
+			var transactions = Object.keys(__private.broadcastTransactions).splice(0, maxspliced).map(tx => {
+				var thistx = __private.broadcastTransactions[tx];
+				delete __private.broadcastTransactions[tx];
+				return tx;
+			});
 			self.broadcast({limit: 20}, {api: '/transactions', data: {transactions: transactions}, method: 'POST'});
 		}
 	}, 3000);
@@ -507,7 +511,7 @@ Transport.prototype.onBroadcastTransaction = function (transaction) {
 	delete transaction.verified;
 	delete transaction.processed;
 
-	__private.broadcastTransactions.push(transaction);
+	__private.broadcastTransactions[transaction.id] = transaction;
 };
 
 //

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -32,7 +32,7 @@ function Transport (cb, scope) {
 			var transactions = Object.keys(__private.broadcastTransactions).splice(0, maxspliced).map(tx => {
 				var thistx = __private.broadcastTransactions[tx];
 				delete __private.broadcastTransactions[tx];
-				return tx;
+				return thisTx;
 			});
 			self.broadcast({limit: 20}, {api: '/transactions', data: {transactions: transactions}, method: 'POST'});
 		}


### PR DESCRIPTION
Also removed accidental log inclusion.